### PR TITLE
Added explicit deny for external DTD

### DIFF
--- a/NUL
+++ b/NUL
@@ -1,0 +1,4 @@
+Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
+openjdk version "20.0.1" 2023-04-18
+OpenJDK Runtime Environment Corretto-20.0.1.9.1 (build 20.0.1+9-FR)
+OpenJDK 64-Bit Server VM Corretto-20.0.1.9.1 (build 20.0.1+9-FR, mixed mode, sharing)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
+#Thu Jul 27 11:26:46 EDT 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-#org.gradle.jvmargs=-Xmx4096m
-org.gradle.jvmargs=-Xms512M -Xmx4g -XX:MaxPermSize=4096m -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvm.options="-Xmx1g"
+zipStoreBase=GRADLE_USER_HOME
+org.gradle.jvmargs=-Xms512M -Xmx4g -XX\:MaxPermSize\=4096m -XX\:MaxMetaspaceSize\=1g -Dkotlin.daemon.jvm.options\="-Xmx1g"

--- a/pacs008/src/main/java/rapide/iso20022/message/pacs008/Pacs008Validator.java
+++ b/pacs008/src/main/java/rapide/iso20022/message/pacs008/Pacs008Validator.java
@@ -58,14 +58,14 @@ public class Pacs008Validator implements IValidator {
             // Guard against XXE injection attacks.
             // See https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md.
             // Turn on secure processing (FSP), disable all external connections.
-            schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            // schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
+            schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             // Disable external entity processing (DTDs) and stylesheet processing
-            // Not needed explicitly, handled by FSP, uncomment if customization is needed and provide protocol(s).
-            // schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            // schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             // Only allow local file or files in jar to be processed for XML schema files
             schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file, jar:file");
+
+            // Not needed explicitly, handled by FSP, uncomment if customization is needed and provide protocol(s).
+            // schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 
             URL xsdResource = getClass().getClassLoader().getResource(schemaFile);
             Schema schema = schemaFactory.newSchema(xsdResource);


### PR DESCRIPTION
*Issue #, if available:* V485424580

*Description of changes:*
Configured Java XML processor to use a local static DTD and disallow any declared DTD included in the XML document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
